### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,43 @@ on:
       - 'serverless.yml'
       - 'layer/**'
       - 'lambdas/**'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: api
+        template: docs/template.md
+      env:
+        COGNITO_USER_POOL_ARN: ${{ secrets.COGNITO_USER_POOL_ARN }}
+        ES_ID: ${{ secrets.ES_ID }}
+        ES_SECRET: ${{ secrets.ES_SECRET }}
+        ES_ENDPOINT: ${{ secrets.ES_ENDPOINT }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,29 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/products-api)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/products-api?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/products-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/products-api/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/products-api/build?label=build&logo=mocha)](https://github.com/kaskadi/products-api/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/products-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/products-api/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/products-api?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/products-api)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/products-api?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/products-api)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/products-api?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/products-api)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/products-api?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/products-api/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/lambdas/delete-product/serverless.yml
+++ b/lambdas/delete-product/serverless.yml
@@ -14,3 +14,5 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint allows client to delete a specific product via its ID.

--- a/lambdas/get-product/serverless.yml
+++ b/lambdas/get-product/serverless.yml
@@ -14,3 +14,5 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint allows client to retrieve data of a specific product via its ID.

--- a/lambdas/products-root-handler/serverless.yml
+++ b/lambdas/products-root-handler/serverless.yml
@@ -13,6 +13,8 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint is a fallback for when client forgets to provide an ID for product data retrieval.
   - http:
       method: post
       path: /
@@ -20,6 +22,8 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint is a fallback for when client forgets to provide an ID for product data update.
   - http:
       method: delete
       path: /
@@ -27,3 +31,5 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint is a fallback for when client forgets to provide an ID for product deletion.

--- a/lambdas/save-product/save-product.js
+++ b/lambdas/save-product/save-product.js
@@ -1,6 +1,6 @@
-const { getBaseResponse, createEsClient } = require('products-api-utils')
+const { getBaseResponse, createEsClient, getId } = require('products-api-utils')
 const saveEntry = require('./helpers/save.js')
 
 module.exports.handler = async (event) => {
-  return await saveEntry(createEsClient(), event.pathParameters.id.replace(/%20/g, ' ').replace(/\+/g, ' '), JSON.parse(event.body), getBaseResponse())
+  return await saveEntry(createEsClient(), getId(event), JSON.parse(event.body), getBaseResponse())
 }

--- a/lambdas/save-product/serverless.yml
+++ b/lambdas/save-product/serverless.yml
@@ -14,3 +14,10 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint allows client to update data of a specific product via its ID. The request body should contain the new product data.
+        body:
+          - key: example-field-1
+            description: A data field to write in the database for the given product
+          - key: example-field-N
+            description: A data field to write in the database for the given product

--- a/lambdas/search-products/serverless.yml
+++ b/lambdas/search-products/serverless.yml
@@ -15,3 +15,14 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint allows client to perform a product search via a query. Results are paginated.
+        queryStringParameters:
+          - key: p
+            description: Request a specific page of the search results.
+            default: 0
+          - key: s
+            description: Amount of search results returned per page.
+            default: 10
+          - key: q
+            description: Query used to perform the product search. This follows [E]lasticSearch query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax).

--- a/layer/serverless.yml
+++ b/layer/serverless.yml
@@ -1,6 +1,6 @@
 path: layer
 name: ${self:service.name}-layer
-description": Layer for ${self:service.name}
+description: Layer for ${self:service.name}
 compatibleRuntimes:
   - nodejs10.x
   - nodejs12.x

--- a/tools/add-lambda/data/serverless.yml
+++ b/tools/add-lambda/data/serverless.yml
@@ -1,5 +1,6 @@
 handler: lambdas/{{name}}/{{name}}.handler
 name: {{name}}
+# customize as needed to connect your lambda function to layers
 layers:
   - { Ref: ApiLayerLambdaLayer }
 package:
@@ -11,3 +12,21 @@ events:
       method: {{method}}
       path: {{path}}
       cors: true
+      # custom fields allowing you to describe your endpoint in order to automatically document it
+      kaskadi-docs:
+        description: placeholder endpoint # describe what this endpoint is used for
+        # this field helps you describe any query string parameter accepted by this endpoint
+        queryStringParameters:
+          - key: key1
+            description: first key
+          - key: key2
+            description: second key
+            default: 35 # you can give a default value
+        # this field helps you describe the body expected by your endpoint
+        body:
+          - key: param1
+            description: first body param
+            default: 'hello'
+          - key: param2
+            description: second body param
+            default: true

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,11 +1,8 @@
-# Layer
-echo "installing layer"
-echo "changing directory"
-cd layer/nodejs
-echo $(pwd)
-echo "installing dependencies"
-npm i
-echo "done"
-echo "cleaning up"
-cd ../..
-echo $(pwd)
+#!/bin/bash
+
+if [ -d "layer" ] && [ -f "layer/nodejs/package.json" ]
+  then
+    cd layer/nodejs || exit
+    npm i
+    cd ../../
+fi


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action.

**New features**
- _docs template:_ template for documentation generation located under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ now includes a `generate-docs` step which automatically generate documentation using `action-generate-docs` and a template located under `docs/template.md`
- _endpoints config file:_ now includes custom `kaskadi-docs` field for documentation generation
- _install script:_ updated install script to handle cases where no layer exists
- _`add-lambda` tool:_ added placeholder `kaskadi-docs` field in base config file
- _layer config file:_ fixed `description` field key